### PR TITLE
Fix navbar item display and admin editor data retrieval

### DIFF
--- a/src/components/Navbar.vue
+++ b/src/components/Navbar.vue
@@ -913,12 +913,6 @@ function resolveDynSrc(src) {
     if (typeof src === 'string' && src.startsWith('/uploads/')) {
       const orig = API_URL || ''
       const base = orig.endsWith('/api') ? orig.slice(0, -4) : orig.replace('/api','')
-      if (src.startsWith('/uploads/avatars/')) {
-        return base + '/api/uploads/avatars/' + src.split('/').pop()
-      }
-      if (src.startsWith('/uploads/items/')) {
-        return base + '/api/items/uploads/' + src.split('/').pop()
-      }
       return base + src
     }
   } catch {}
@@ -926,19 +920,13 @@ function resolveDynSrc(src) {
 }
 
 function getDynNavbarAssetStyle(asset) {
-  const s = (asset && (isMobile.value ? asset.navbarStyleMobile : asset.navbarStyle))
-    || (asset && (isMobile.value ? asset.collectionStyleMobile : asset.collectionStyle))
-    || asset?.style || {}
-  const num = (v) => {
-    const n = Number(v)
-    return Number.isFinite(n) ? n : null
-  }
-  const style = { position: 'absolute', objectFit: s.objectFit || 'contain', zIndex: num(s.zIndex) ?? 1 }
-  const top = num(s.top); if (top !== null) style.top = top + 'px'
-  const left = num(s.left); if (left !== null) style.left = left + 'px'
-  const w = num(s.width); if (w !== null) style.width = w + 'px'
-  const h = num(s.height); if (h !== null) style.height = h + 'px'
-  const r = num(s.rotate); if (r !== null) style.transform = `rotate(${r}deg)`
+  const s = (asset && asset.navbarStyle) || asset?.style || {}
+  const style = { position: 'absolute', objectFit: s.objectFit || 'contain', zIndex: typeof s.zIndex === 'number' ? s.zIndex : 1 }
+  if (typeof s.top === 'number') style.top = s.top + 'px'
+  if (typeof s.left === 'number') style.left = s.left + 'px'
+  if (typeof s.width === 'number') style.width = s.width + 'px'
+  if (typeof s.height === 'number') style.height = s.height + 'px'
+  if (typeof s.rotate === 'number') style.transform = `rotate(${s.rotate}deg)`
   return style
 }
 function getDynNavbarOverlayStyle(asset) {


### PR DESCRIPTION
Restore dynamic navbar item display and styling by reverting `resolveDynSrc` and `getDynNavbarAssetStyle` to their previous, simpler logic.

Previous changes to `resolveDynSrc` introduced unnecessary path handling, and `getDynNavbarAssetStyle` added complex mobile/collection style logic, both of which prevented dynamic navbar items from appearing or having their correct size/position as defined in the admin editor. This PR reverts these functions to ensure proper rendering.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e4e2f9e-563f-4dbe-946f-f235953dedc6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5e4e2f9e-563f-4dbe-946f-f235953dedc6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

