### PR TITLE
Appliquer la couleur de bordure classique au classement

### DIFF
--- a/src/components/ShopPopup.vue
+++ b/src/components/ShopPopup.vue
@@ -2879,9 +2879,9 @@ const sortedLeaderboardUsers = computed(() => {
     height: 16px !important;
   }
 
-  /* Bordure par défaut autour des avatars dans le leaderboard (overridable inline) */
+  /* Bordure par défaut autour des avatars dans le leaderboard (la couleur est gérée en inline par getAvatarBorderStyle) */
   .leaderboard-container .user-avatar {
-    border: 3px solid black;
+    border: 3px solid transparent;
     border-radius: 12px !important;
     box-sizing: border-box !important;
     position: relative !important; /* Ajouté pour que les items soient positionnés relativement */


### PR DESCRIPTION
Allow equipped border colors to display in the leaderboard by removing the forced black border.

Previously, a CSS rule in `ShopPopup.vue` enforced a `3px solid black` border on leaderboard avatars, overriding the dynamically selected border color. Changing this to `transparent` allows the `getAvatarBorderStyle` function to correctly apply the user's equipped border color or gradient.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c32ecd9-e166-4ec0-ada7-589e880a45a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3c32ecd9-e166-4ec0-ada7-589e880a45a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

