### PR TITLE
Debug leaderboard item layering issue

### DIFF
--- a/frontend/src/components/AdminItemEditor.vue
+++ b/frontend/src/components/AdminItemEditor.vue
@@ -1177,6 +1177,8 @@ function clearForm() {
 .inspector .row { display: flex; gap: 6px; margin-top: 8px; }
 .nudge-row { justify-content: flex-start; }
 .layer-controls { display:flex; gap:8px; align-items:center; margin-top:8px; flex-wrap: wrap; }
+.layer-controls .btn.tiny { transition: background-color .15s ease, color .15s ease, border-color .15s ease; }
+.layer-controls .btn.tiny:hover { background:#f3f4f6; }
 .layer-controls .btn.tiny.active { background:#10b981; color:#fff; border-color:#10b981; }
 /* Ligne du picker de background */
 .bg-picker-row { display: flex; gap: 16px; align-items: center; margin-top: 8px; flex-wrap: wrap; }

--- a/frontend/src/components/AdminItemEditor.vue
+++ b/frontend/src/components/AdminItemEditor.vue
@@ -280,6 +280,8 @@ const fileInput = ref(null)
 const activeCanvas = ref('collection') // collection | leaderboard | avatar | navbar
 const activeDevice = ref('desktop') // desktop | mobile
 const selectedIndex = ref(null)
+// Mémorise le dernier choix explicite de cible pour le leaderboard
+const lastLeaderboardTarget = ref(null) // 'user-avatar-container' | 'user-avatar' | null
 const DEFAULT_STYLE = { top: 0, left: 0, width: 100, rotate: 0, objectFit: 'contain', zIndex: 1 }
 function getApiOrigin() {
   const api = API_URL || ''
@@ -931,6 +933,7 @@ function getActiveAssetLeaderboardTarget() {
 
 function setLeaderboardTarget(target) {
   const t = (target === 'user-avatar-container') ? 'user-avatar-container' : 'user-avatar'
+  lastLeaderboardTarget.value = t
   // 1) Base assets
   try {
     if (Array.isArray(form.value.assets)) {
@@ -1062,6 +1065,13 @@ async function updateItem() {
   // Synchroniser les modifications avec les assets de la variante avant la sauvegarde
   syncVariantAssets()
   const payload = sanitizeItem(form.value)
+  // Si l'utilisateur a cliqué un bouton de cible, garantir que la cible est posée partout avant PUT
+  try {
+    if (lastLeaderboardTarget.value) {
+      if (Array.isArray(payload.assets)) payload.assets.forEach(a => { a.meta = a.meta || {}; a.meta.leaderboardTarget = lastLeaderboardTarget.value })
+      if (Array.isArray(payload.variants)) payload.variants.forEach(v => { if (Array.isArray(v.assets)) v.assets.forEach(a => { a.meta = a.meta || {}; a.meta.leaderboardTarget = lastLeaderboardTarget.value }) })
+    }
+  } catch {}
   const res = await secureApiCall(`/items/${editingId.value}`, {
     method: 'PUT',
     body: JSON.stringify(payload)

--- a/frontend/src/components/AdminItemEditor.vue
+++ b/frontend/src/components/AdminItemEditor.vue
@@ -971,15 +971,8 @@ async function saveItem() {
   // Synchroniser les modifications avec les assets de la variante avant la sauvegarde
   syncVariantAssets()
   const payload = sanitizeItem(form.value)
-  // Forcer tous les assets à cibler le conteneur du leaderboard pour les dynamiques (temporaire, demandé)
-  try {
-    if (Array.isArray(payload.assets)) {
-      payload.assets.forEach(a => { a.meta = a.meta || {}; a.meta.leaderboardTarget = 'user-avatar-container' })
-    }
-    if (Array.isArray(payload.variants)) {
-      payload.variants.forEach(v => { if (Array.isArray(v.assets)) v.assets.forEach(a => { a.meta = a.meta || {}; a.meta.leaderboardTarget = 'user-avatar-container' }) })
-    }
-  } catch {}
+  // Respecter le choix de cible fait via les boutons (conteneur vs avatar)
+  // Aucun forçage global: chaque asset conserve son meta.leaderboardTarget défini par l'utilisateur.
   // Rien à faire de spécial ici: les propriétés *StyleMobile sont déjà dans form.assets via ensureStyle
   const res = await secureApiCall('/items', {
     method: 'POST',

--- a/frontend/src/components/AdminItemEditor.vue
+++ b/frontend/src/components/AdminItemEditor.vue
@@ -930,16 +930,30 @@ function getActiveAssetLeaderboardTarget() {
 }
 
 function setLeaderboardTarget(target) {
-  const assets = activeAssets()
   const t = (target === 'user-avatar-container') ? 'user-avatar-container' : 'user-avatar'
-  if (Array.isArray(assets) && assets.length) {
-    // Appliquer sur l'asset sélectionné et, par sécurité, sur tous les assets de l'onglet courant
-    for (const a of assets) {
-      if (!a) continue
-      a.meta = a.meta || {}
-      a.meta.leaderboardTarget = t
+  // 1) Base assets
+  try {
+    if (Array.isArray(form.value.assets)) {
+      for (const a of form.value.assets) {
+        if (!a) continue
+        a.meta = a.meta || {}
+        a.meta.leaderboardTarget = t
+      }
     }
-  }
+  } catch {}
+  // 2) Variants assets
+  try {
+    if (Array.isArray(form.value.variants)) {
+      for (const v of form.value.variants) {
+        if (!v || !Array.isArray(v.assets)) continue
+        for (const a of v.assets) {
+          if (!a) continue
+          a.meta = a.meta || {}
+          a.meta.leaderboardTarget = t
+        }
+      }
+    }
+  } catch {}
 }
 
 async function handleFiles(e) {}

--- a/frontend/src/components/AdminItemEditor.vue
+++ b/frontend/src/components/AdminItemEditor.vue
@@ -239,8 +239,8 @@
           <button class="btn tiny" @click="setLeaderboardPlacement('above')">Au-dessus</button>
           <!-- Cible du rendu: avatar vs conteneur -->
           <span style="margin-left:12px;">Cible :</span>
-          <button class="btn tiny" :class="{ active: getActiveAssetLeaderboardTarget() === 'user-avatar' }" @click="setLeaderboardTarget('user-avatar')">Avatar</button>
-          <button class="btn tiny" :class="{ active: getActiveAssetLeaderboardTarget() === 'user-avatar-container' }" @click="setLeaderboardTarget('user-avatar-container')">Conteneur</button>
+          <button class="btn tiny" :class="{ active: getActiveAssetLeaderboardTarget() === 'user-avatar-container' }" @click="setLeaderboardTarget('user-avatar-container')">Dans le conteneur</button>
+          <button class="btn tiny" :class="{ active: getActiveAssetLeaderboardTarget() === 'user-avatar' }" @click="setLeaderboardTarget('user-avatar')">(Ancien) Dans l'avatar</button>
         </div>
         <!-- Contrôle de position pour la Navbar -->
         <div v-if="activeCanvas==='navbar' && selectedIndex !== null" class="layer-controls">
@@ -906,10 +906,6 @@ function setLeaderboardPlacement(placement) {
   if (!asset.meta) asset.meta = {}
   if (placement !== 'above' && placement !== 'inside') placement = 'below'
   asset.meta.leaderboardPlacement = placement
-  // TEMP: forcer la cible conteneur pour le canvas leaderboard
-  if (activeCanvas.value === 'leaderboard') {
-    asset.meta.leaderboardTarget = 'user-avatar-container'
-  }
 }
 
 function setNavbarPlacement(placement) {

--- a/frontend/src/components/AdminItemEditor.vue
+++ b/frontend/src/components/AdminItemEditor.vue
@@ -958,7 +958,7 @@ async function uploadAssets() {
   const data = await res.json()
   if (data.success) {
     const target = editingVariantIndex.value === -1 ? form.value.assets : ((form.value.variants[editingVariantIndex.value].assets ||= []))
-    for (const file of data.files) target.push(sanitizeAsset({ src: file.url, style: { top: 0, left: 0, width: 100, height: 100 }, meta: { leaderboardPlacement: 'below', navbarPlacement: 'below', leaderboardTarget: 'user-avatar', container: '' } }))
+    for (const file of data.files) target.push(sanitizeAsset({ src: file.url, style: { top: 0, left: 0, width: 100, height: 100 }, meta: { leaderboardPlacement: 'below', navbarPlacement: 'below', leaderboardTarget: 'user-avatar-container', container: '' } }))
   } else {
     alert('Upload échoué')
   }
@@ -968,13 +968,22 @@ function addAssetFromUrl() {
   const url = prompt('URL de l\'image (déjà sur le serveur)')
   if (!url) return
   const target = editingVariantIndex.value === -1 ? form.value.assets : ((form.value.variants[editingVariantIndex.value].assets ||= []))
-  target.push(sanitizeAsset({ src: url, style: { top: 0, left: 0, width: 100 }, meta: { leaderboardPlacement: 'below', navbarPlacement: 'below', leaderboardTarget: 'user-avatar', container: '' } }))
+  target.push(sanitizeAsset({ src: url, style: { top: 0, left: 0, width: 100 }, meta: { leaderboardPlacement: 'below', navbarPlacement: 'below', leaderboardTarget: 'user-avatar-container', container: '' } }))
 }
 
 async function saveItem() {
   // Synchroniser les modifications avec les assets de la variante avant la sauvegarde
   syncVariantAssets()
   const payload = sanitizeItem(form.value)
+  // Forcer tous les assets à cibler le conteneur du leaderboard pour les dynamiques (temporaire, demandé)
+  try {
+    if (Array.isArray(payload.assets)) {
+      payload.assets.forEach(a => { a.meta = a.meta || {}; a.meta.leaderboardTarget = 'user-avatar-container' })
+    }
+    if (Array.isArray(payload.variants)) {
+      payload.variants.forEach(v => { if (Array.isArray(v.assets)) v.assets.forEach(a => { a.meta = a.meta || {}; a.meta.leaderboardTarget = 'user-avatar-container' }) })
+    }
+  } catch {}
   // Rien à faire de spécial ici: les propriétés *StyleMobile sont déjà dans form.assets via ensureStyle
   const res = await secureApiCall('/items', {
     method: 'POST',

--- a/frontend/src/components/AdminItemEditor.vue
+++ b/frontend/src/components/AdminItemEditor.vue
@@ -237,6 +237,10 @@
           <button class="btn tiny" @click="setLeaderboardPlacement('below')">Derrière</button>
           <button class="btn tiny" @click="setLeaderboardPlacement('inside')">Dans l'avatar</button>
           <button class="btn tiny" @click="setLeaderboardPlacement('above')">Au-dessus</button>
+          <!-- Cible du rendu: avatar vs conteneur -->
+          <span style="margin-left:12px;">Cible :</span>
+          <button class="btn tiny" :class="{ active: getActiveAssetLeaderboardTarget() === 'user-avatar' }" @click="setLeaderboardTarget('user-avatar')">Avatar</button>
+          <button class="btn tiny" :class="{ active: getActiveAssetLeaderboardTarget() === 'user-avatar-container' }" @click="setLeaderboardTarget('user-avatar-container')">Conteneur</button>
         </div>
         <!-- Contrôle de position pour la Navbar -->
         <div v-if="activeCanvas==='navbar' && selectedIndex !== null" class="layer-controls">
@@ -912,6 +916,27 @@ function setNavbarPlacement(placement) {
   asset.meta.navbarPlacement = placement
 }
 
+function getActiveAssetLeaderboardTarget() {
+  try {
+    if (selectedIndex.value === null) return 'user-avatar'
+    const assets = activeAssets()
+    const asset = Array.isArray(assets) ? assets[selectedIndex.value] : null
+    if (!asset) return 'user-avatar'
+    const t = asset.meta && (asset.meta.leaderboardTarget || (asset.meta.container === 'user-avatar-container' ? 'user-avatar-container' : null))
+    return t || 'user-avatar'
+  } catch { return 'user-avatar' }
+}
+
+function setLeaderboardTarget(target) {
+  if (selectedIndex.value === null) return
+  const assets = activeAssets()
+  const asset = Array.isArray(assets) ? assets[selectedIndex.value] : null
+  if (!asset) return
+  if (!asset.meta) asset.meta = {}
+  const t = (target === 'user-avatar-container') ? 'user-avatar-container' : 'user-avatar'
+  asset.meta.leaderboardTarget = t
+}
+
 async function handleFiles(e) {}
 
 async function uploadAssets() {
@@ -1152,6 +1177,7 @@ function clearForm() {
 .inspector .row { display: flex; gap: 6px; margin-top: 8px; }
 .nudge-row { justify-content: flex-start; }
 .layer-controls { display:flex; gap:8px; align-items:center; margin-top:8px; flex-wrap: wrap; }
+.layer-controls .btn.tiny.active { background:#10b981; color:#fff; border-color:#10b981; }
 /* Ligne du picker de background */
 .bg-picker-row { display: flex; gap: 16px; align-items: center; margin-top: 8px; flex-wrap: wrap; }
 /* cercle + bordure verte en mode collection */

--- a/frontend/src/components/AdminItemEditor.vue
+++ b/frontend/src/components/AdminItemEditor.vue
@@ -709,6 +709,8 @@ function sanitizeAsset(a) {
 
 function sanitizeItem(it) {
   const clone = JSON.parse(JSON.stringify(it || {}))
+  // Préserver le meta item-level (pour lecture côté ShopPopup si asset-level absent)
+  if (!clone.meta || typeof clone.meta !== 'object') clone.meta = {}
   if (!Array.isArray(clone.assets)) clone.assets = []
   clone.assets = clone.assets.map(sanitizeAsset)
   if (!clone.backgrounds) clone.backgrounds = { collection: null, leaderboard: null, avatar: null, navbar: null, 'popup-style': null }
@@ -934,6 +936,11 @@ function getActiveAssetLeaderboardTarget() {
 function setLeaderboardTarget(target) {
   const t = (target === 'user-avatar-container') ? 'user-avatar-container' : 'user-avatar'
   lastLeaderboardTarget.value = t
+  // Écrire au niveau item pour fallback de lecture
+  try {
+    if (!form.value.meta || typeof form.value.meta !== 'object') form.value.meta = {}
+    form.value.meta.leaderboardTarget = t
+  } catch {}
   // 1) Base assets
   try {
     if (Array.isArray(form.value.assets)) {

--- a/frontend/src/components/AdminItemEditor.vue
+++ b/frontend/src/components/AdminItemEditor.vue
@@ -690,6 +690,10 @@ function sanitizeAsset(a) {
       ...(a.meta || {}),
       leaderboardPlacement: (a.meta && a.meta.leaderboardPlacement) || 'below',
       navbarPlacement: (a.meta && a.meta.navbarPlacement) || 'below',
+      // Normaliser la cible du leaderboard: utiliser leaderboardTarget, avec fallback depuis l'ancien champ "container"
+      leaderboardTarget: (a.meta && a.meta.leaderboardTarget)
+        ? a.meta.leaderboardTarget
+        : ((a.meta && a.meta.container === 'user-avatar-container') ? 'user-avatar-container' : 'user-avatar'),
       container: (a.meta && a.meta.container) || ''
     }
   }
@@ -741,6 +745,14 @@ function sanitizeItem(it) {
           if (!asset.navbarStyle) asset.navbarStyle = { top: 0, left: 0, width: 100, rotate: 0, objectFit: 'contain', zIndex: 1 }
           if (!asset.navbarStyleMobile) asset.navbarStyleMobile = { top: 0, left: 0, width: 100, rotate: 0, objectFit: 'contain', zIndex: 1 }
           if (!asset.popupStyleStyle) asset.popupStyleStyle = { top: 0, left: 0, width: 100, rotate: 0, objectFit: 'contain', zIndex: 1 }
+          // Normaliser meta pour l'affichage du leaderboard (compat avec ancien champ "container")
+          if (!asset.meta) asset.meta = {}
+          if (asset.meta.leaderboardPlacement !== 'above' && asset.meta.leaderboardPlacement !== 'inside' && asset.meta.leaderboardPlacement !== 'below') {
+            asset.meta.leaderboardPlacement = 'below'
+          }
+          if (!asset.meta.leaderboardTarget) {
+            asset.meta.leaderboardTarget = (asset.meta.container === 'user-avatar-container') ? 'user-avatar-container' : 'user-avatar'
+          }
           return asset
         })
       }
@@ -915,7 +927,7 @@ async function uploadAssets() {
   const data = await res.json()
   if (data.success) {
     const target = editingVariantIndex.value === -1 ? form.value.assets : ((form.value.variants[editingVariantIndex.value].assets ||= []))
-    for (const file of data.files) target.push(sanitizeAsset({ src: file.url, style: { top: 0, left: 0, width: 100, height: 100 }, meta: { leaderboardPlacement: 'below', navbarPlacement: 'below', container: '' } }))
+    for (const file of data.files) target.push(sanitizeAsset({ src: file.url, style: { top: 0, left: 0, width: 100, height: 100 }, meta: { leaderboardPlacement: 'below', navbarPlacement: 'below', leaderboardTarget: 'user-avatar', container: '' } }))
   } else {
     alert('Upload échoué')
   }
@@ -925,7 +937,7 @@ function addAssetFromUrl() {
   const url = prompt('URL de l\'image (déjà sur le serveur)')
   if (!url) return
   const target = editingVariantIndex.value === -1 ? form.value.assets : ((form.value.variants[editingVariantIndex.value].assets ||= []))
-  target.push(sanitizeAsset({ src: url, style: { top: 0, left: 0, width: 100 }, meta: { leaderboardPlacement: 'below', navbarPlacement: 'below', container: '' } }))
+  target.push(sanitizeAsset({ src: url, style: { top: 0, left: 0, width: 100 }, meta: { leaderboardPlacement: 'below', navbarPlacement: 'below', leaderboardTarget: 'user-avatar', container: '' } }))
 }
 
 async function saveItem() {

--- a/frontend/src/components/AdminItemEditor.vue
+++ b/frontend/src/components/AdminItemEditor.vue
@@ -930,13 +930,16 @@ function getActiveAssetLeaderboardTarget() {
 }
 
 function setLeaderboardTarget(target) {
-  if (selectedIndex.value === null) return
   const assets = activeAssets()
-  const asset = Array.isArray(assets) ? assets[selectedIndex.value] : null
-  if (!asset) return
-  if (!asset.meta) asset.meta = {}
   const t = (target === 'user-avatar-container') ? 'user-avatar-container' : 'user-avatar'
-  asset.meta.leaderboardTarget = t
+  if (Array.isArray(assets) && assets.length) {
+    // Appliquer sur l'asset sélectionné et, par sécurité, sur tous les assets de l'onglet courant
+    for (const a of assets) {
+      if (!a) continue
+      a.meta = a.meta || {}
+      a.meta.leaderboardTarget = t
+    }
+  }
 }
 
 async function handleFiles(e) {}

--- a/frontend/src/components/AdminItemEditor.vue
+++ b/frontend/src/components/AdminItemEditor.vue
@@ -904,6 +904,10 @@ function setLeaderboardPlacement(placement) {
   if (!asset.meta) asset.meta = {}
   if (placement !== 'above' && placement !== 'inside') placement = 'below'
   asset.meta.leaderboardPlacement = placement
+  // TEMP: forcer la cible conteneur pour le canvas leaderboard
+  if (activeCanvas.value === 'leaderboard') {
+    asset.meta.leaderboardTarget = 'user-avatar-container'
+  }
 }
 
 function setNavbarPlacement(placement) {

--- a/frontend/src/components/AdminItemEditor.vue
+++ b/frontend/src/components/AdminItemEditor.vue
@@ -698,6 +698,8 @@ function sanitizeAsset(a) {
       leaderboardTarget: (a.meta && a.meta.leaderboardTarget)
         ? a.meta.leaderboardTarget
         : ((a.meta && a.meta.container === 'user-avatar-container') ? 'user-avatar-container' : 'user-avatar'),
+      // Classe dynamique optionnelle pour calquer un gabarit leaderboard (par défaut on utilisera equipped-galaxie)
+      dynamicClass: (a.meta && a.meta.dynamicClass) || '',
       container: (a.meta && a.meta.container) || ''
     }
   }

--- a/frontend/src/components/ShopPopup.vue
+++ b/frontend/src/components/ShopPopup.vue
@@ -1480,8 +1480,8 @@ function getDynLeaderboardAssetClass(asset) {
     const base = String(asset && asset.meta && asset.meta.dynamicClass || '').trim()
     if (base) return base
   } catch {}
-  // Classe par défaut pour les dynamiques container: suivez le gabarit Galaxie
-  return 'equipped-galaxie'
+  // Par défaut, ne pas appliquer de classe afin de respecter les styles définis via l'éditeur
+  return ''
 }
 
 // Style spécial pour les items dynamiques qui ciblent user-avatar-container avec placement "above"

--- a/frontend/src/components/ShopPopup.vue
+++ b/frontend/src/components/ShopPopup.vue
@@ -1510,10 +1510,11 @@ function getDynLeaderboardContainerOverlayStyle(asset) {
 // Déterminer la cible effective (avatar vs container) pour un asset dynamique
 function getEffectiveLeaderboardTarget(item, asset) {
   try {
-    // Par défaut pour les dynamiques: conteneur, mais si l'éditeur a explicitement mis "user-avatar", on respecte
+    // Dyn: si meta.leaderboardTarget est défini, on l'applique. Sinon, fallback conteneur
     if (item && item.isDynamic) {
-      const targetDyn = asset && asset.meta && (asset.meta.leaderboardTarget || (asset.meta.container === 'user-avatar-container' ? 'user-avatar-container' : null))
-      return targetDyn || 'user-avatar-container'
+      if (asset && asset.meta && asset.meta.leaderboardTarget) return String(asset.meta.leaderboardTarget)
+      const fromContainerFlag = asset && asset.meta && asset.meta.container === 'user-avatar-container'
+      return fromContainerFlag ? 'user-avatar-container' : 'user-avatar-container'
     }
     const assetTarget = asset && asset.meta && (asset.meta.leaderboardTarget || (asset.meta.container === 'user-avatar-container' ? 'user-avatar-container' : null))
     if (assetTarget) return String(assetTarget)

--- a/frontend/src/components/ShopPopup.vue
+++ b/frontend/src/components/ShopPopup.vue
@@ -556,8 +556,8 @@
               <template v-if="getUserEquippedItemData(user)">
                 <img
                   v-for="(a, ai) in getEquippedAssetsForLeaderboard(user)"
-                  v-if="isAssetTargetingContainer(getUserEquippedItemData(user), a) && (!a || !a.meta || a.meta.leaderboardPlacement === 'above' || (!a.meta.leaderboardPlacement))"
-                  :key="'container-above-overlay-' + ai + '-' + dynamicVariantsState"
+                  v-if="isAssetTargetingContainer(getUserEquippedItemData(user), a) && (!a || !a.meta || a.meta.leaderboardPlacement !== 'below')"
+                  :key="'container-overlay-' + ai + '-' + dynamicVariantsState"
                   :src="resolveAssetSrc(a.src)"
                   :style="getDynLeaderboardContainerOverlayStyle(a)"
                   class="dynamic-container-overlay"
@@ -571,8 +571,8 @@
                     v-for="(a, ai) in (Array.isArray(getUserEquippedItemData(user).variants) && getUserEquippedItemData(user).variants.length > 0
                       ? getDynVariantAssetsForLeaderboard(getUserEquippedItemData(user))
                       : getUserEquippedItemData(user).assets)"
-                    v-if="isAssetTargetingContainer(getUserEquippedItemData(user), a) && a && a.meta && a.meta.leaderboardPlacement === 'below'"
-                    :key="'dyn-container-below-' + ai + '-' + dynamicVariantsState"
+                    v-if="isAssetTargetingAvatar(getUserEquippedItemData(user), a) && a && a.meta && a.meta.leaderboardPlacement === 'below'"
+                    :key="'dyn-avatar-below-' + ai + '-' + dynamicVariantsState"
                     :src="resolveAssetSrc(a.src)"
                     :style="getDynLeaderboardAssetStyle(a)"
                   />
@@ -848,8 +848,8 @@
                     v-for="(a, ai) in (Array.isArray(getUserEquippedItemData(user).variants) && getUserEquippedItemData(user).variants.length > 0
                       ? getDynVariantAssetsForLeaderboard(getUserEquippedItemData(user))
                       : getUserEquippedItemData(user).assets)"
-                    v-if="isAssetTargetingContainer(getUserEquippedItemData(user), a) && a && a.meta && a.meta.leaderboardPlacement === 'inside'"
-                    :key="'dyn-container-inside-' + ai + '-' + dynamicVariantsState"
+                    v-if="isAssetTargetingAvatar(getUserEquippedItemData(user), a) && a && a.meta && a.meta.leaderboardPlacement === 'inside'"
+                    :key="'dyn-avatar-inside-' + ai + '-' + dynamicVariantsState"
                     :src="resolveAssetSrc(a.src)"
                     :style="getDynLeaderboardAssetStyle(a)"
                   />

--- a/frontend/src/components/ShopPopup.vue
+++ b/frontend/src/components/ShopPopup.vue
@@ -1512,9 +1512,12 @@ function getEffectiveLeaderboardTarget(item, asset) {
   try {
     // Dyn: si meta.leaderboardTarget est défini, on l'applique. Sinon, fallback conteneur
     if (item && item.isDynamic) {
+      // 1) Priorité asset.meta.leaderboardTarget
       if (asset && asset.meta && asset.meta.leaderboardTarget) return String(asset.meta.leaderboardTarget)
-      const fromContainerFlag = asset && asset.meta && asset.meta.container === 'user-avatar-container'
-      return fromContainerFlag ? 'user-avatar-container' : 'user-avatar-container'
+      // 2) Sinon, si item.meta.leaderboardTarget est posé au niveau item
+      if (item && item.meta && item.meta.leaderboardTarget) return String(item.meta.leaderboardTarget)
+      // 3) Sinon, fallback conteneur
+      return 'user-avatar-container'
     }
     const assetTarget = asset && asset.meta && (asset.meta.leaderboardTarget || (asset.meta.container === 'user-avatar-container' ? 'user-avatar-container' : null))
     if (assetTarget) return String(assetTarget)

--- a/frontend/src/components/ShopPopup.vue
+++ b/frontend/src/components/ShopPopup.vue
@@ -1510,6 +1510,11 @@ function getDynLeaderboardContainerOverlayStyle(asset) {
 // Déterminer la cible effective (avatar vs container) pour un asset dynamique
 function getEffectiveLeaderboardTarget(item, asset) {
   try {
+    // Par défaut, les items dynamiques se rendent dans le conteneur du leaderboard
+    if (item && item.isDynamic) {
+      const targetDyn = asset && asset.meta && (asset.meta.leaderboardTarget || (asset.meta.container === 'user-avatar-container' ? 'user-avatar-container' : null))
+      return targetDyn || 'user-avatar-container'
+    }
     const assetTarget = asset && asset.meta && (asset.meta.leaderboardTarget || (asset.meta.container === 'user-avatar-container' ? 'user-avatar-container' : null))
     if (assetTarget) return String(assetTarget)
     const itemTarget = item && item.meta && (item.meta.leaderboardTarget || (item.meta.container === 'user-avatar-container' ? 'user-avatar-container' : null))

--- a/frontend/src/components/ShopPopup.vue
+++ b/frontend/src/components/ShopPopup.vue
@@ -1510,10 +1510,10 @@ function getDynLeaderboardContainerOverlayStyle(asset) {
 // Déterminer la cible effective (avatar vs container) pour un asset dynamique
 function getEffectiveLeaderboardTarget(item, asset) {
   try {
-    // Respecter la cible définie par l'éditeur (conteneur vs avatar) sans forcer
+    // Par défaut pour les dynamiques: conteneur, mais si l'éditeur a explicitement mis "user-avatar", on respecte
     if (item && item.isDynamic) {
       const targetDyn = asset && asset.meta && (asset.meta.leaderboardTarget || (asset.meta.container === 'user-avatar-container' ? 'user-avatar-container' : null))
-      if (targetDyn) return String(targetDyn)
+      return targetDyn || 'user-avatar-container'
     }
     const assetTarget = asset && asset.meta && (asset.meta.leaderboardTarget || (asset.meta.container === 'user-avatar-container' ? 'user-avatar-container' : null))
     if (assetTarget) return String(assetTarget)

--- a/frontend/src/components/ShopPopup.vue
+++ b/frontend/src/components/ShopPopup.vue
@@ -1496,9 +1496,9 @@ function getDynLeaderboardContainerOverlayStyle(asset) {
 // Déterminer la cible effective (avatar vs container) pour un asset dynamique
 function getEffectiveLeaderboardTarget(item, asset) {
   try {
-    const assetTarget = asset && asset.meta && asset.meta.leaderboardTarget
+    const assetTarget = asset && asset.meta && (asset.meta.leaderboardTarget || (asset.meta.container === 'user-avatar-container' ? 'user-avatar-container' : null))
     if (assetTarget) return String(assetTarget)
-    const itemTarget = item && item.meta && item.meta.leaderboardTarget
+    const itemTarget = item && item.meta && (item.meta.leaderboardTarget || (item.meta.container === 'user-avatar-container' ? 'user-avatar-container' : null))
     if (itemTarget) return String(itemTarget)
   } catch {}
   return 'user-avatar'

--- a/frontend/src/components/ShopPopup.vue
+++ b/frontend/src/components/ShopPopup.vue
@@ -564,6 +564,7 @@
                     :key="'dyn-container-below-' + ai + '-' + dynamicVariantsState"
                     :src="resolveAssetSrc(a.src)"
                     :style="getDynLeaderboardAssetStyle(a)"
+                    :class="getDynLeaderboardAssetClass(a)"
                   />
                 </template>
 
@@ -841,6 +842,20 @@
                     :key="'dyn-container-inside-' + ai + '-' + dynamicVariantsState"
                     :src="resolveAssetSrc(a.src)"
                     :style="getDynLeaderboardAssetStyle(a)"
+                    :class="getDynLeaderboardAssetClass(a)"
+                  />
+                </template>
+                <!-- Items dynamiques ciblant le conteneur : ABOVE -->
+                <template v-if="getUserEquippedItemData(user) && getUserEquippedItemData(user).isDynamic">
+                  <img
+                    v-for="(a, ai) in (Array.isArray(getUserEquippedItemData(user).variants) && getUserEquippedItemData(user).variants.length > 0
+                      ? getDynVariantAssetsForLeaderboard(getUserEquippedItemData(user))
+                      : getUserEquippedItemData(user).assets)"
+                    v-if="isAssetTargetingContainer(getUserEquippedItemData(user), a) && (!a || !a.meta || a.meta.leaderboardPlacement === 'above' || (!a.meta.leaderboardPlacement))"
+                    :key="'dyn-container-above-' + ai + '-' + dynamicVariantsState"
+                    :src="resolveAssetSrc(a.src)"
+                    :style="getDynLeaderboardAssetStyle(a)"
+                    :class="getDynLeaderboardAssetClass(a)"
                   />
                 </template>
                 
@@ -1457,6 +1472,16 @@ function getDynLeaderboardAssetStyle(asset) {
   if (typeof s.height === 'number') style.height = s.height + 'px'
   if (typeof s.rotate === 'number') style.transform = `rotate(${s.rotate}deg)`
   return style
+}
+
+// Classe CSS pour mimer l'effet "Discord/Galaxie" depuis un item dynamique ciblant le conteneur
+function getDynLeaderboardAssetClass(asset) {
+  try {
+    const base = String(asset && asset.meta && asset.meta.dynamicClass || '').trim()
+    if (base) return base
+  } catch {}
+  // Classe par défaut pour les dynamiques container: suivez le gabarit Galaxie
+  return 'equipped-galaxie'
 }
 
 // Style spécial pour les items dynamiques qui ciblent user-avatar-container avec placement "above"

--- a/frontend/src/components/ShopPopup.vue
+++ b/frontend/src/components/ShopPopup.vue
@@ -1510,10 +1510,10 @@ function getDynLeaderboardContainerOverlayStyle(asset) {
 // Déterminer la cible effective (avatar vs container) pour un asset dynamique
 function getEffectiveLeaderboardTarget(item, asset) {
   try {
-    // Par défaut, les items dynamiques se rendent dans le conteneur du leaderboard
+    // Respecter la cible définie par l'éditeur (conteneur vs avatar) sans forcer
     if (item && item.isDynamic) {
       const targetDyn = asset && asset.meta && (asset.meta.leaderboardTarget || (asset.meta.container === 'user-avatar-container' ? 'user-avatar-container' : null))
-      return targetDyn || 'user-avatar-container'
+      if (targetDyn) return String(targetDyn)
     }
     const assetTarget = asset && asset.meta && (asset.meta.leaderboardTarget || (asset.meta.container === 'user-avatar-container' ? 'user-avatar-container' : null))
     if (assetTarget) return String(assetTarget)

--- a/frontend/src/components/ShopPopup.vue
+++ b/frontend/src/components/ShopPopup.vue
@@ -552,27 +552,16 @@
             
                         <!-- Avatar et infos utilisateur -->
             <div class="user-info">
-              <!-- Overlays ciblant user-avatar-container avec placement "above" (rendu hors du conteneur) -->
-              <template v-if="getUserEquippedItemData(user)">
-                <img
-                  v-for="(a, ai) in getEquippedAssetsForLeaderboard(user)"
-                  v-if="isAssetTargetingContainer(getUserEquippedItemData(user), a) && (!a || !a.meta || a.meta.leaderboardPlacement !== 'below')"
-                  :key="'container-overlay-' + ai + '-' + dynamicVariantsState"
-                  :src="resolveAssetSrc(a.src)"
-                  :style="getDynLeaderboardContainerOverlayStyle(a)"
-                  class="dynamic-container-overlay"
-                />
-              </template>
 
               <div class="user-avatar-container" @click="openLeaderboardProfile(user)">
-                <!-- Items dynamiques ciblant user-avatar-container avec placement "below" (derrière tout) -->
+                <!-- Items dynamiques ciblant le conteneur : BELOW (derrière tout) -->
                 <template v-if="getUserEquippedItemData(user) && getUserEquippedItemData(user).isDynamic">
                   <img
                     v-for="(a, ai) in (Array.isArray(getUserEquippedItemData(user).variants) && getUserEquippedItemData(user).variants.length > 0
                       ? getDynVariantAssetsForLeaderboard(getUserEquippedItemData(user))
                       : getUserEquippedItemData(user).assets)"
-                    v-if="isAssetTargetingAvatar(getUserEquippedItemData(user), a) && a && a.meta && a.meta.leaderboardPlacement === 'below'"
-                    :key="'dyn-avatar-below-' + ai + '-' + dynamicVariantsState"
+                    v-if="isAssetTargetingContainer(getUserEquippedItemData(user), a) && a && a.meta && a.meta.leaderboardPlacement === 'below'"
+                    :key="'dyn-container-below-' + ai + '-' + dynamicVariantsState"
                     :src="resolveAssetSrc(a.src)"
                     :style="getDynLeaderboardAssetStyle(a)"
                   />
@@ -842,14 +831,14 @@
                   </template>
                 </div>
 
-                <!-- Items dynamiques ciblant user-avatar-container avec placement "inside" (techniquement équivalent à above car on est déjà dans le container) -->
+                <!-- Items dynamiques ciblant le conteneur : INSIDE -->
                 <template v-if="getUserEquippedItemData(user) && getUserEquippedItemData(user).isDynamic">
                   <img
                     v-for="(a, ai) in (Array.isArray(getUserEquippedItemData(user).variants) && getUserEquippedItemData(user).variants.length > 0
                       ? getDynVariantAssetsForLeaderboard(getUserEquippedItemData(user))
                       : getUserEquippedItemData(user).assets)"
-                    v-if="isAssetTargetingAvatar(getUserEquippedItemData(user), a) && a && a.meta && a.meta.leaderboardPlacement === 'inside'"
-                    :key="'dyn-avatar-inside-' + ai + '-' + dynamicVariantsState"
+                    v-if="isAssetTargetingContainer(getUserEquippedItemData(user), a) && a && a.meta && a.meta.leaderboardPlacement === 'inside'"
+                    :key="'dyn-container-inside-' + ai + '-' + dynamicVariantsState"
                     :src="resolveAssetSrc(a.src)"
                     :style="getDynLeaderboardAssetStyle(a)"
                   />

--- a/frontend/src/components/ShopPopup.vue
+++ b/frontend/src/components/ShopPopup.vue
@@ -1512,12 +1512,14 @@ function getEffectiveLeaderboardTarget(item, asset) {
   try {
     // Dyn: si meta.leaderboardTarget est défini, on l'applique. Sinon, fallback conteneur
     if (item && item.isDynamic) {
-      // 1) Priorité asset.meta.leaderboardTarget
-      if (asset && asset.meta && asset.meta.leaderboardTarget) return String(asset.meta.leaderboardTarget)
-      // 2) Sinon, si item.meta.leaderboardTarget est posé au niveau item
-      if (item && item.meta && item.meta.leaderboardTarget) return String(item.meta.leaderboardTarget)
-      // 3) Sinon, fallback conteneur
-      return 'user-avatar-container'
+      // 1) Priorité: valeur explicite fixée par l'éditeur au niveau asset
+      const explicit = asset && asset.meta && asset.meta.leaderboardTarget
+      if (explicit) return String(explicit)
+      // 2) Compat: ancien champ meta.container
+      const legacy = asset && asset.meta && asset.meta.container === 'user-avatar-container'
+      if (legacy) return 'user-avatar-container'
+      // 3) Par défaut: avatar (les boutons définissent explicitement la cible si besoin)
+      return 'user-avatar'
     }
     const assetTarget = asset && asset.meta && (asset.meta.leaderboardTarget || (asset.meta.container === 'user-avatar-container' ? 'user-avatar-container' : null))
     if (assetTarget) return String(assetTarget)


### PR DESCRIPTION
Fix dynamic item placement in the leaderboard by harmonizing `leaderboardTarget` and `container` meta fields.

The admin editor saved the target for dynamic item overlays in `meta.container`, but the leaderboard component expected `meta.leaderboardTarget`. This led to dynamic items configured for `user-avatar-container` always appearing inside `user-avatar` in the leaderboard. The fix ensures both components correctly interpret the placement setting through a fallback mechanism and consistent saving.

---
<a href="https://cursor.com/background-agent?bcId=bc-5ce4e0b5-e62f-46a8-9b7f-86ee813493f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5ce4e0b5-e62f-46a8-9b7f-86ee813493f4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

