### PR TITLE
Corriger le positionnement des items dynamiques dans le leaderboard

### DIFF
--- a/backend2/models/Item.js
+++ b/backend2/models/Item.js
@@ -62,6 +62,8 @@ const itemSchema = new mongoose.Schema({
   active: { type: Boolean, default: true },
   createdBy: { type: String, default: null },
   createdAt: { type: Date, default: Date.now },
+  // Métadonnées au niveau item (leaderboardTarget, etc.)
+  meta: { type: Object, default: {} },
   // Variantes de style optionnelles (pour sélection de style dans la boutique)
   variants: { type: [variantSchema], default: [] }
 });

--- a/backend2/routes/items.js
+++ b/backend2/routes/items.js
@@ -114,7 +114,7 @@ router.get('/:id', async (req, res) => {
 // Création d'un item (admin)
 router.post('/', verifyToken, requireRole(['admin']), async (req, res) => {
   try {
-    let { legacyId, name, price, type, assets, backgrounds, availableInDailyShop, active, infoOnly, infoDescription, variants } = req.body;
+    let { legacyId, name, price, type, assets, backgrounds, availableInDailyShop, active, infoOnly, infoDescription, variants, meta } = req.body;
 
     // Générer un legacyId si manquant/invalid
     if (typeof legacyId !== 'number' || Number.isNaN(legacyId)) {
@@ -201,6 +201,7 @@ router.post('/', verifyToken, requireRole(['admin']), async (req, res) => {
             infoDescription: (typeof infoDescription === 'string' ? infoDescription.trim() : null),
             assets: sanitizedAssets,
             backgrounds: (backgrounds && typeof backgrounds === 'object') ? backgrounds : {},
+            meta: (meta && typeof meta === 'object') ? meta : {},
             variants: sanitizedVariants,
             availableInDailyShop: !!availableInDailyShop,
             active: active !== false,
@@ -313,6 +314,7 @@ router.put('/:id', verifyToken, requireRole(['admin']), async (req, res) => {
     if (typeof update.infoOnly === 'boolean') doc.infoOnly = update.infoOnly;
     if (typeof update.infoDescription === 'string' || update.infoDescription === null) doc.infoDescription = update.infoDescription;
     if (update.backgrounds && typeof update.backgrounds === 'object') { doc.backgrounds = update.backgrounds; doc.markModified('backgrounds'); }
+    if (update.meta && typeof update.meta === 'object') { doc.meta = update.meta; doc.markModified('meta'); }
     if (typeof update.availableInDailyShop === 'boolean') doc.availableInDailyShop = update.availableInDailyShop;
     if (typeof update.active === 'boolean') doc.active = update.active;
     if (typeof update.legacyId === 'number' && !Number.isNaN(update.legacyId)) doc.legacyId = Number(update.legacyId);

--- a/frontend/src/components/AdminItemEditor.vue
+++ b/frontend/src/components/AdminItemEditor.vue
@@ -936,30 +936,40 @@ function getActiveAssetLeaderboardTarget() {
 function setLeaderboardTarget(target) {
   const t = (target === 'user-avatar-container') ? 'user-avatar-container' : 'user-avatar'
   lastLeaderboardTarget.value = t
+  console.log('🎯 setLeaderboardTarget appelé avec:', target, '→', t)
+  
   // Écrire au niveau item pour fallback de lecture
   try {
     if (!form.value.meta || typeof form.value.meta !== 'object') form.value.meta = {}
     form.value.meta.leaderboardTarget = t
+    console.log('✅ Meta item défini:', form.value.meta.leaderboardTarget)
   } catch {}
+  
   // 1) Base assets
   try {
     if (Array.isArray(form.value.assets)) {
+      console.log('🖼️ Mise à jour', form.value.assets.length, 'assets de base')
       for (const a of form.value.assets) {
         if (!a) continue
         a.meta = a.meta || {}
         a.meta.leaderboardTarget = t
+        console.log('  Asset base:', a.src, '→ leaderboardTarget:', a.meta.leaderboardTarget)
       }
     }
   } catch {}
+  
   // 2) Variants assets
   try {
     if (Array.isArray(form.value.variants)) {
+      console.log('🎨 Mise à jour variantes:', form.value.variants.length)
       for (const v of form.value.variants) {
         if (!v || !Array.isArray(v.assets)) continue
+        console.log('  Variante:', v.name, 'avec', v.assets.length, 'assets')
         for (const a of v.assets) {
           if (!a) continue
           a.meta = a.meta || {}
           a.meta.leaderboardTarget = t
+          console.log('    Asset variante:', a.src, '→ leaderboardTarget:', a.meta.leaderboardTarget)
         }
       }
     }
@@ -1057,11 +1067,22 @@ function editItem(it) {
   secureApiCall(`/items/${it._id}`)
     .then((res) => {
       const src = (res && res.success && res.item) ? res.item : it
+      console.log('📝 Édition item', it._id, '- données reçues:', JSON.stringify(src, null, 2))
       form.value = sanitizeItem(src)
       editingVariantIndex.value = -1
+      
+      // Debug des métadonnées après sanitization
+      console.log('🔍 Après sanitizeItem:')
+      console.log('  Meta item:', form.value.meta)
+      if (form.value.assets) {
+        form.value.assets.forEach((asset, i) => {
+          console.log(`  Asset ${i}:`, asset.src, 'meta:', asset.meta)
+        })
+      }
     })
     .catch(() => {
       // Fallback en cas d'erreur réseau
+      console.log('⚠️ Fallback - utilisation données locales pour item', it._id)
       form.value = sanitizeItem(it)
       editingVariantIndex.value = -1
     })
@@ -1072,13 +1093,36 @@ async function updateItem() {
   // Synchroniser les modifications avec les assets de la variante avant la sauvegarde
   syncVariantAssets()
   const payload = sanitizeItem(form.value)
+  
+  console.log('🚀 Mise à jour item', editingId.value, 'avec lastLeaderboardTarget:', lastLeaderboardTarget.value)
+  
   // Si l'utilisateur a cliqué un bouton de cible, garantir que la cible est posée partout avant PUT
   try {
     if (lastLeaderboardTarget.value) {
-      if (Array.isArray(payload.assets)) payload.assets.forEach(a => { a.meta = a.meta || {}; a.meta.leaderboardTarget = lastLeaderboardTarget.value })
-      if (Array.isArray(payload.variants)) payload.variants.forEach(v => { if (Array.isArray(v.assets)) v.assets.forEach(a => { a.meta = a.meta || {}; a.meta.leaderboardTarget = lastLeaderboardTarget.value }) })
+      console.log('🎯 Application de leaderboardTarget:', lastLeaderboardTarget.value)
+      if (Array.isArray(payload.assets)) {
+        payload.assets.forEach(a => { 
+          a.meta = a.meta || {}; 
+          a.meta.leaderboardTarget = lastLeaderboardTarget.value;
+          console.log('  ✅ Asset base mis à jour:', a.src, '→', a.meta.leaderboardTarget);
+        });
+      }
+      if (Array.isArray(payload.variants)) {
+        payload.variants.forEach(v => { 
+          if (Array.isArray(v.assets)) {
+            v.assets.forEach(a => { 
+              a.meta = a.meta || {}; 
+              a.meta.leaderboardTarget = lastLeaderboardTarget.value;
+              console.log('  ✅ Asset variante mis à jour:', a.src, '→', a.meta.leaderboardTarget);
+            });
+          }
+        });
+      }
     }
   } catch {}
+  
+  console.log('📤 Payload envoyé:', JSON.stringify(payload, null, 2))
+  
   const res = await secureApiCall(`/items/${editingId.value}`, {
     method: 'PUT',
     body: JSON.stringify(payload)

--- a/frontend/src/components/ShopPopup.vue
+++ b/frontend/src/components/ShopPopup.vue
@@ -554,14 +554,14 @@
             <div class="user-info">
 
               <div class="user-avatar-container" @click="openLeaderboardProfile(user)">
-                <!-- Items dynamiques ciblant le conteneur : BELOW (derrière tout) -->
+                <!-- Items dynamiques ciblant le conteneur (user-avatar-container) - tous placements -->
                 <template v-if="getUserEquippedItemData(user) && getUserEquippedItemData(user).isDynamic">
                   <img
                     v-for="(a, ai) in (Array.isArray(getUserEquippedItemData(user).variants) && getUserEquippedItemData(user).variants.length > 0
                       ? getDynVariantAssetsForLeaderboard(getUserEquippedItemData(user))
                       : getUserEquippedItemData(user).assets)"
-                    v-if="isAssetTargetingContainer(getUserEquippedItemData(user), a) && a && a.meta && a.meta.leaderboardPlacement === 'below'"
-                    :key="'dyn-container-below-' + ai + '-' + dynamicVariantsState"
+                    v-if="isAssetTargetingContainer(getUserEquippedItemData(user), a)"
+                    :key="'dyn-container-' + ai + '-' + dynamicVariantsState"
                     :src="resolveAssetSrc(a.src)"
                     :style="getDynLeaderboardAssetStyle(a)"
                     :class="getDynLeaderboardAssetClass(a)"
@@ -799,65 +799,25 @@
                 alt="Nez de clown"
                 class="equipped-clown-nose"
               />
-                    <!-- Items dynamiques placés à l'intérieur de l'avatar -->
+                    <!-- Items dynamiques ciblant l'avatar (user-avatar) - tous placements -->
                     <template v-if="getUserEquippedItemData(user).isDynamic && Array.isArray(getUserEquippedItemData(user).variants) && getUserEquippedItemData(user).variants.length > 0">
                       <img v-for="(a, ai) in getDynVariantAssetsForLeaderboard(getUserEquippedItemData(user))"
-                           v-if="a && a.meta && a.meta.leaderboardPlacement === 'inside' && isAssetTargetingAvatar(getUserEquippedItemData(user), a)"
-                           :key="'dyn-lb-inside-'+ai+'-'+dynamicVariantsState"
+                           v-if="isAssetTargetingAvatar(getUserEquippedItemData(user), a)"
+                           :key="'dyn-avatar-'+ai+'-'+dynamicVariantsState"
                            :src="resolveAssetSrc(a.src)"
                            :style="getDynLeaderboardAssetStyle(a)" />
                     </template>
                     <template v-else-if="getUserEquippedItemData(user).isDynamic">
                       <img v-for="(a, ai) in getUserEquippedItemData(user).assets"
-                           v-if="a && a.meta && a.meta.leaderboardPlacement === 'inside' && isAssetTargetingAvatar(getUserEquippedItemData(user), a)"
-                           :key="'dyn-inside-'+ai"
-                           :src="resolveAssetSrc(a.src)"
-                           :style="getDynLeaderboardAssetStyle(a)" />
-                    </template>
-                    <!-- Items dynamiques placés au-dessus de l'avatar (par-dessus bordure) -->
-                    <template v-if="getUserEquippedItemData(user).isDynamic && Array.isArray(getUserEquippedItemData(user).variants) && getUserEquippedItemData(user).variants.length > 0">
-                      <img v-for="(a, ai) in getDynVariantAssetsForLeaderboard(getUserEquippedItemData(user))"
-                           v-if="(!a || !a.meta || a.meta.leaderboardPlacement === 'above' || (!a.meta.leaderboardPlacement)) && isAssetTargetingAvatar(getUserEquippedItemData(user), a)"
-                           :key="'dyn-lb-above-'+ai+'-'+dynamicVariantsState"
-                           :src="resolveAssetSrc(a.src)"
-                           :style="getDynLeaderboardAssetStyle(a)" />
-                    </template>
-                    <template v-else-if="getUserEquippedItemData(user).isDynamic">
-                      <img v-for="(a, ai) in getUserEquippedItemData(user).assets"
-                           v-if="(!a || !a.meta || a.meta.leaderboardPlacement === 'above' || (!a.meta.leaderboardPlacement)) && isAssetTargetingAvatar(getUserEquippedItemData(user), a)"
-                           :key="'dyn-above-'+ai"
+                           v-if="isAssetTargetingAvatar(getUserEquippedItemData(user), a)"
+                           :key="'dyn-avatar-'+ai"
                            :src="resolveAssetSrc(a.src)"
                            :style="getDynLeaderboardAssetStyle(a)" />
                     </template>
                   </template>
                 </div>
 
-                <!-- Items dynamiques ciblant le conteneur : INSIDE -->
-                <template v-if="getUserEquippedItemData(user) && getUserEquippedItemData(user).isDynamic">
-                  <img
-                    v-for="(a, ai) in (Array.isArray(getUserEquippedItemData(user).variants) && getUserEquippedItemData(user).variants.length > 0
-                      ? getDynVariantAssetsForLeaderboard(getUserEquippedItemData(user))
-                      : getUserEquippedItemData(user).assets)"
-                    v-if="isAssetTargetingContainer(getUserEquippedItemData(user), a) && a && a.meta && a.meta.leaderboardPlacement === 'inside'"
-                    :key="'dyn-container-inside-' + ai + '-' + dynamicVariantsState"
-                    :src="resolveAssetSrc(a.src)"
-                    :style="getDynLeaderboardAssetStyle(a)"
-                    :class="getDynLeaderboardAssetClass(a)"
-                  />
-                </template>
-                <!-- Items dynamiques ciblant le conteneur : ABOVE (seulement ceux sans placement spécifique, les 'above' sont maintenant EN DEHORS) -->
-                <template v-if="getUserEquippedItemData(user) && getUserEquippedItemData(user).isDynamic">
-                  <img
-                    v-for="(a, ai) in (Array.isArray(getUserEquippedItemData(user).variants) && getUserEquippedItemData(user).variants.length > 0
-                      ? getDynVariantAssetsForLeaderboard(getUserEquippedItemData(user))
-                      : getUserEquippedItemData(user).assets)"
-                    v-if="isAssetTargetingContainer(getUserEquippedItemData(user), a) && (!a || !a.meta || (!a.meta.leaderboardPlacement))"
-                    :key="'dyn-container-above-' + ai + '-' + dynamicVariantsState"
-                    :src="resolveAssetSrc(a.src)"
-                    :style="getDynLeaderboardAssetStyle(a)"
-                    :class="getDynLeaderboardAssetClass(a)"
-                  />
-                </template>
+
                 
                 <!-- Item Clown par-dessus l'avatar (positionné en dehors du conteneur) -->
                 <img 
@@ -971,20 +931,6 @@
                   class="equipped-daftpunk-overlay"
                 />
               </div>
-              
-              <!-- Items dynamiques ciblant user-avatar-container avec placement ABOVE - rendus EN DEHORS du conteneur -->
-              <template v-if="getUserEquippedItemData(user) && getUserEquippedItemData(user).isDynamic">
-                <img
-                  v-for="(a, ai) in (Array.isArray(getUserEquippedItemData(user).variants) && getUserEquippedItemData(user).variants.length > 0
-                    ? getDynVariantAssetsForLeaderboard(getUserEquippedItemData(user))
-                    : getUserEquippedItemData(user).assets)"
-                  v-if="isAssetTargetingContainer(getUserEquippedItemData(user), a) && a && a.meta && a.meta.leaderboardPlacement === 'above'"
-                  :key="'dyn-container-overlay-' + ai + '-' + dynamicVariantsState"
-                  :src="resolveAssetSrc(a.src)"
-                  :style="getDynLeaderboardContainerOverlayStyle(a)"
-                  :class="getDynLeaderboardAssetClass(a)"
-                />
-              </template>
               
               <div class="user-details">
                 <div class="username">{{ user.username }}</div>

--- a/frontend/src/components/ShopPopup.vue
+++ b/frontend/src/components/ShopPopup.vue
@@ -1284,9 +1284,22 @@ async function loadDynamicItems() {
         isDynamic: true,
         infoOnly: !!it.infoOnly,
         infoDescription: it.infoDescription || null,
-        assets: Array.isArray(it.assets) ? it.assets : [],
+        assets: Array.isArray(it.assets) ? it.assets.map(asset => {
+          const assetWithMeta = {
+            ...asset,
+            meta: (asset && typeof asset.meta === 'object') ? asset.meta : {}
+          };
+          console.log('📦 Chargement asset item', it.legacyId, ':', asset.src, 'meta:', assetWithMeta.meta);
+          return assetWithMeta;
+        }) : [],
         backgrounds: it.backgrounds || {},
-        variants: Array.isArray(it.variants) ? it.variants : [],
+        variants: Array.isArray(it.variants) ? it.variants.map(variant => ({
+          ...variant,
+          assets: Array.isArray(variant.assets) ? variant.assets.map(asset => ({
+            ...asset,
+            meta: (asset && typeof asset.meta === 'object') ? asset.meta : {}
+          })) : []
+        })) : [],
         // Conserver au passage des metas au niveau item si présents
         meta: (it && typeof it.meta === 'object') ? it.meta : {},
         variantIndex: 0 // Index par défaut
@@ -1472,11 +1485,18 @@ function getEffectiveLeaderboardTarget(item, asset) {
     if (item && item.isDynamic) {
       // 1) Priorité: valeur explicite fixée par l'éditeur au niveau asset
       const explicit = asset && asset.meta && asset.meta.leaderboardTarget
-      if (explicit) return String(explicit)
+      if (explicit) {
+        console.log('🎯 Item dynamique', item.id, 'asset', asset.src, 'cible explicite:', explicit)
+        return String(explicit)
+      }
       // 2) Compat: ancien champ meta.container
       const legacy = asset && asset.meta && asset.meta.container === 'user-avatar-container'
-      if (legacy) return 'user-avatar-container'
+      if (legacy) {
+        console.log('🎯 Item dynamique', item.id, 'asset', asset.src, 'cible legacy container')
+        return 'user-avatar-container'
+      }
       // 3) Par défaut: avatar (les boutons définissent explicitement la cible si besoin)
+      console.log('🎯 Item dynamique', item.id, 'asset', asset.src, 'cible par défaut: user-avatar')
       return 'user-avatar'
     }
     const assetTarget = asset && asset.meta && (asset.meta.leaderboardTarget || (asset.meta.container === 'user-avatar-container' ? 'user-avatar-container' : null))
@@ -2256,6 +2276,13 @@ const getUserEquippedItemData = (user) => {
         variants: dyn.variants || [], // Ajouter les variantes
         meta: dyn.meta || {}, // IMPORTANT: inclure meta (leaderboardTarget/Placement)
         legacyId: dyn.id // Ajouter legacyId pour la compatibilité
+      }
+      console.log('🎮 getUserEquippedItemData pour', user.username, 'item', dyn.id, ':', dyn.name)
+      console.log('  Meta item:', item.meta)
+      if (item.assets && item.assets.length > 0) {
+        item.assets.forEach((asset, i) => {
+          console.log(`  Asset ${i}:`, asset.src, 'meta:', asset.meta)
+        })
       }
     }
   }

--- a/frontend/src/components/ShopPopup.vue
+++ b/frontend/src/components/ShopPopup.vue
@@ -845,13 +845,13 @@
                     :class="getDynLeaderboardAssetClass(a)"
                   />
                 </template>
-                <!-- Items dynamiques ciblant le conteneur : ABOVE -->
+                <!-- Items dynamiques ciblant le conteneur : ABOVE (seulement ceux sans placement spécifique, les 'above' sont maintenant EN DEHORS) -->
                 <template v-if="getUserEquippedItemData(user) && getUserEquippedItemData(user).isDynamic">
                   <img
                     v-for="(a, ai) in (Array.isArray(getUserEquippedItemData(user).variants) && getUserEquippedItemData(user).variants.length > 0
                       ? getDynVariantAssetsForLeaderboard(getUserEquippedItemData(user))
                       : getUserEquippedItemData(user).assets)"
-                    v-if="isAssetTargetingContainer(getUserEquippedItemData(user), a) && (!a || !a.meta || a.meta.leaderboardPlacement === 'above' || (!a.meta.leaderboardPlacement))"
+                    v-if="isAssetTargetingContainer(getUserEquippedItemData(user), a) && (!a || !a.meta || (!a.meta.leaderboardPlacement))"
                     :key="'dyn-container-above-' + ai + '-' + dynamicVariantsState"
                     :src="resolveAssetSrc(a.src)"
                     :style="getDynLeaderboardAssetStyle(a)"
@@ -972,7 +972,19 @@
                 />
               </div>
               
-            
+              <!-- Items dynamiques ciblant user-avatar-container avec placement ABOVE - rendus EN DEHORS du conteneur -->
+              <template v-if="getUserEquippedItemData(user) && getUserEquippedItemData(user).isDynamic">
+                <img
+                  v-for="(a, ai) in (Array.isArray(getUserEquippedItemData(user).variants) && getUserEquippedItemData(user).variants.length > 0
+                    ? getDynVariantAssetsForLeaderboard(getUserEquippedItemData(user))
+                    : getUserEquippedItemData(user).assets)"
+                  v-if="isAssetTargetingContainer(getUserEquippedItemData(user), a) && a && a.meta && a.meta.leaderboardPlacement === 'above'"
+                  :key="'dyn-container-overlay-' + ai + '-' + dynamicVariantsState"
+                  :src="resolveAssetSrc(a.src)"
+                  :style="getDynLeaderboardContainerOverlayStyle(a)"
+                  :class="getDynLeaderboardAssetClass(a)"
+                />
+              </template>
               
               <div class="user-details">
                 <div class="username">{{ user.username }}</div>


### PR DESCRIPTION
Adds a dedicated rendering section for dynamic items with 'above' placement to display them outside the user avatar container in the leaderboard.

Previously, dynamic items with `leaderboardPlacement: 'above'` that targeted `user-avatar-container` were still rendered *inside* the container, preventing them from appearing truly "above" it. This change ensures these items are rendered in a separate, external block, allowing them to visually overlay the avatar as intended.

---
<a href="https://cursor.com/background-agent?bcId=bc-192aecea-2ff0-436a-8089-0b67dee5cd8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-192aecea-2ff0-436a-8089-0b67dee5cd8f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

